### PR TITLE
Add CORS for ArticleController + ApiPageable swagger annotation

### DIFF
--- a/src/main/java/com/github/bpiatek/bbghbackend/controller/ArticlesController.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/controller/ArticlesController.java
@@ -6,17 +6,20 @@ import com.github.bpiatek.bbghbackend.dao.ArticleRepository;
 import com.github.bpiatek.bbghbackend.dao.CommentRepository;
 import com.github.bpiatek.bbghbackend.model.Article;
 import com.github.bpiatek.bbghbackend.model.Comment;
+import com.github.bpiatek.bbghbackend.swagger.ApiPageable;
 import io.swagger.annotations.*;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 /**
  * Created by Bartosz Piatek on 12/07/2020
  */
 @Log4j2
 @Api(tags = "Articles and comments controller")
+@CrossOrigin
 @RestController
 @RequestMapping(value = "/api/articles")
 class ArticlesController {
@@ -34,8 +37,9 @@ class ArticlesController {
   @ApiResponses(value = {
       @ApiResponse(code = ORDINAL_200_OK, message = "Successfully retrieved all articles"),
   })
+  @ApiPageable
   @GetMapping
-  Page<Article> getAllArticlesPageable(Pageable pageable) {
+  Page<Article> getAllArticlesPageable(@ApiIgnore Pageable pageable) {
     return articleRepository.findAll(pageable);
   }
 

--- a/src/main/java/com/github/bpiatek/bbghbackend/controller/ArticlesController.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/controller/ArticlesController.java
@@ -47,8 +47,9 @@ class ArticlesController {
   @ApiResponses(value = {
       @ApiResponse(code = ORDINAL_200_OK, message = "Successfully retrieved comments for a given article"),
   })
+  @ApiPageable
   @GetMapping("{articleId}/comments")
-  Page<Comment> getAllCommentsForArticlePageable(@PathVariable Long articleId, Pageable pageable) {
+  Page<Comment> getAllCommentsForArticlePageable(@PathVariable Long articleId, @ApiIgnore Pageable pageable) {
     return commentRepository.findByArticleId(articleId, pageable);
   }
 }

--- a/src/main/java/com/github/bpiatek/bbghbackend/swagger/ApiPageable.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/swagger/ApiPageable.java
@@ -1,0 +1,19 @@
+package com.github.bpiatek.bbghbackend.swagger;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiImplicitParams({
+    @ApiImplicitParam(name = "page", dataType = "int", paramType = "query", defaultValue = "0", value = "Results page you want to retrieve (0..N)"),
+    @ApiImplicitParam(name = "size", dataType = "int", paramType = "query", defaultValue = "20", value = "Number of records per page."),
+    @ApiImplicitParam(name = "sort", allowMultiple = true, dataType = "string", paramType = "query", value = "Sorting criteria in the format: property(,asc|desc). "
+        + "Default sort order is ascending. " + "Multiple sort criteria are supported.")})
+public @interface ApiPageable {
+}


### PR DESCRIPTION
Naprawiony błąd w dokumentacji swaggera dotyczący Pageable (https://github.com/springfox/springfox/issues/2623) 

No i CORS-y. Bo konieczne.