### PR TITLE
added mentions filtering by sentiment

### DIFF
--- a/src/main/java/com/github/bpiatek/bbghbackend/controller/MentionsController.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/controller/MentionsController.java
@@ -8,6 +8,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 import com.github.bpiatek.bbghbackend.model.comment.CommentFacade;
 import com.github.bpiatek.bbghbackend.model.mention.Mention;
 import com.github.bpiatek.bbghbackend.model.mention.MentionFacade;
+import com.github.bpiatek.bbghbackend.model.mention.MentionSentiment;
 import com.github.bpiatek.bbghbackend.model.mention.api.CreateMentionRequest;
 import com.github.bpiatek.bbghbackend.model.mention.api.MentionResponse;
 import com.github.bpiatek.bbghbackend.model.mention.api.MentionSentimentRequest;
@@ -21,6 +22,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
+
+import java.util.List;
 
 /**
  * @author Błażej Rybarkiewicz <b.rybarkiewicz@gmail.com>
@@ -47,14 +50,14 @@ class MentionsController {
     return ResponseEntity.ok(mentionFacade.findById(id).toMentionResponse());
   }
 
-  @ApiOperation(value = "Get all mentions")
+  @ApiOperation(value = "Search for mentions")
   @ApiResponses(value = {
       @ApiResponse(code = ORDINAL_200_OK, message = "Successfully retrieved all mentions"),
   })
   @ApiPageable
   @GetMapping
-  Page<MentionResponse> getAllMentions(@ApiIgnore Pageable pageable) {
-    return mentionFacade.findAll(pageable);
+  Page<MentionResponse> search(@ApiIgnore Pageable pageable, @RequestParam(required = false) List<MentionSentiment> sentiments) {
+    return mentionFacade.search(pageable, sentiments);
   }
 
   @ApiOperation(value = "Create mention.")

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/mention/MentionRepository.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/mention/MentionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -20,6 +21,8 @@ interface MentionRepository extends Repository<Mention, Long> {
   Optional<Mention> findById(Long id);
 
   Page<Mention> findAll(Pageable pageable);
+
+  Page<Mention> findBySentimentIn(Pageable pageable, List<MentionSentiment> sentiments);
 
   @Modifying
   @Query("UPDATE Mention m SET m.sentiment = :sentiment WHERE m.id = :id")


### PR DESCRIPTION
jeśli się dobrze zrozumielismy to zrobilem cos takiego:
![Zrzut ekranu 2020-11-30 o 13 40 40](https://user-images.githubusercontent.com/42154043/100612770-c8ba9b80-3313-11eb-9ba1-d8577437ecbc.png)
Można nie wybierać zadnego sentymentu to wyszuka wszystko lub wybrać jeden lub więcej.
Przykładowe zapytania:
Wyszykiwanie wszystkiego -> api/mentions?page=0&size=20
Wyszukiwanie z jednym sentymentem -> api/mentions?page=0&sentiments=POSITIVE&size=20
Wyszukiwanie z wieloma -> api/mentions?page=0&sentiments=POSITIVE&sentiments=NEUTRAL&size=20
zamiennie do powyzszego można użyć: api/mentions?sentiments=POSITIVE%2CNEUTRAL&page=0&size=20

