### PR TITLE
Feature filter by players ids

### DIFF
--- a/src/main/java/com/github/bpiatek/bbghbackend/controller/MentionsController.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/controller/MentionsController.java
@@ -55,9 +55,12 @@ class MentionsController {
       @ApiResponse(code = ORDINAL_200_OK, message = "Successfully retrieved all mentions"),
   })
   @ApiPageable
+  @ApiImplicitParam(name = "ids", dataType = "array", paramType = "query", value = "Players ids. \n If you want to pass multiple ids separate them by commas ','")
   @GetMapping
-  Page<MentionResponse> search(@ApiIgnore Pageable pageable, @RequestParam(required = false) List<MentionSentiment> sentiments) {
-    return mentionFacade.search(pageable, sentiments);
+  Page<MentionResponse> search(@ApiIgnore Pageable pageable,
+                               @RequestParam(required = false) List<MentionSentiment> sentiments,
+                               @RequestParam(required = false) List<Long> ids) {
+    return mentionFacade.search(pageable, sentiments, ids);
   }
 
   @ApiOperation(value = "Create mention.")

--- a/src/main/java/com/github/bpiatek/bbghbackend/controller/MentionsController.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/controller/MentionsController.java
@@ -8,6 +8,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 import com.github.bpiatek.bbghbackend.model.comment.CommentFacade;
 import com.github.bpiatek.bbghbackend.model.mention.Mention;
 import com.github.bpiatek.bbghbackend.model.mention.MentionFacade;
+import com.github.bpiatek.bbghbackend.model.mention.MentionSentiment;
 import com.github.bpiatek.bbghbackend.model.mention.api.CreateMentionRequest;
 import com.github.bpiatek.bbghbackend.model.mention.api.MentionResponse;
 import com.github.bpiatek.bbghbackend.model.mention.api.MentionSentimentRequest;
@@ -21,6 +22,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
+
+import java.util.List;
 
 /**
  * @author Błażej Rybarkiewicz <b.rybarkiewicz@gmail.com>
@@ -47,14 +50,14 @@ class MentionsController {
     return ResponseEntity.ok(mentionFacade.findById(id).toMentionResponse());
   }
 
-  @ApiOperation(value = "Get all mentions")
+  @ApiOperation(value = "Search for mentions")
   @ApiResponses(value = {
       @ApiResponse(code = ORDINAL_200_OK, message = "Successfully retrieved all mentions"),
   })
   @ApiPageable
   @GetMapping
-  Page<MentionResponse> getAllMentions(@ApiIgnore Pageable pageable) {
-    return mentionFacade.findAll(pageable);
+  Page<MentionResponse> search(@ApiIgnore Pageable pageable, @RequestParam(required = false) List<MentionSentiment> sentiments) {
+    return mentionFacade.search(pageable, sentiments);
   }
 
   @ApiOperation(value = "Create mention.")

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/mention/MentionFacade.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/mention/MentionFacade.java
@@ -26,12 +26,10 @@ public class MentionFacade {
 
   public Mention save(Mention player) {
     Mention mention = mentionRepository.save(player);
-    log.info(
-        "Mention with ID: {} saved! Player ID: {}, comment ID: {}",
+    log.info("Mention with ID: {} saved! Player ID: {}, comment ID: {}",
         mention.getId(),
         mention.getPlayer().getId(),
-        mention.getComment().getId()
-    );
+        mention.getComment().getId());
 
     return mention;
   }
@@ -40,9 +38,11 @@ public class MentionFacade {
     return mentionRepository.findById(id).orElseThrow(() -> new MentionNotFoundException(id));
   }
 
-  public Page<MentionResponse> search(Pageable pageable, List<MentionSentiment> sentiments) {
+  public Page<MentionResponse> search(Pageable pageable, List<MentionSentiment> sentiments, List<Long> ids) {
     if (sentiments != null) {
       return findBySentiments(pageable, sentiments);
+    } else if (ids != null) {
+      return findByPlayersIds(pageable, ids);
     } else {
       return findAll(pageable);
     }
@@ -63,6 +63,13 @@ public class MentionFacade {
     List<MentionResponse> mentions = toMentionResponseList(mentionsWithSentimentsPageable);
 
     return new PageImpl<>(mentions, mentionsWithSentimentsPageable.getPageable(), mentionsWithSentimentsPageable.getTotalElements());
+  }
+
+  private Page<MentionResponse> findByPlayersIds(Pageable pageable, List<Long> ids) {
+    Page<Mention> mentionsWithPlayersIdsPageable = mentionRepository.findByPlayerIdIn(pageable, ids);
+    List<MentionResponse> mentions = toMentionResponseList(mentionsWithPlayersIdsPageable);
+
+    return new PageImpl<>(mentions, mentionsWithPlayersIdsPageable.getPageable(), mentionsWithPlayersIdsPageable.getTotalElements());
   }
 
   private Page<MentionResponse> findAll(Pageable pageable) {

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/mention/MentionRepository.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/mention/MentionRepository.java
@@ -24,6 +24,8 @@ interface MentionRepository extends Repository<Mention, Long> {
 
   Page<Mention> findBySentimentIn(Pageable pageable, List<MentionSentiment> sentiments);
 
+  Page<Mention> findByPlayerIdIn(Pageable pageable, List<Long> ids);
+
   @Modifying
   @Query("UPDATE Mention m SET m.sentiment = :sentiment WHERE m.id = :id")
   int setMentionSentimentById(@Param("id") Long id, @Param("sentiment") MentionSentiment sentiment);

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/mention/MentionRepository.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/mention/MentionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -20,6 +21,8 @@ interface MentionRepository extends Repository<Mention, Long> {
   Optional<Mention> findById(Long id);
 
   Page<Mention> findAll(Pageable pageable);
+
+  Page<Mention> findBySentimentIn(Pageable pageable, List<MentionSentiment> sentiments);
 
   @Modifying
   @Query("UPDATE Mention m SET m.sentiment = :sentiment WHERE m.id = :id")


### PR DESCRIPTION
![Zrzut ekranu 2020-11-30 o 14 51 15](https://user-images.githubusercontent.com/42154043/100618672-70d46280-331c-11eb-9080-8f38218eafdd.png)
Mozna podac jeden lub wiecej ID do wyfiltrowania wzmianek.
Przykładowe zapytanie dla ID: 1 i 8 -> 
`/api/mentions?ids=1%2C8&page=0&size=20`

Na chwilę obecną nie działa wyszukanie jednoczesnie po ID i Sentymencie czyli:
Podaj mi pozytywne wzmianki dla zawodników z id: 1 i 7.

Jak bedzie to potrzebne, to to ogarne. Puki co jedziemy po minimum tego co potrzebujemy, zeby bylo szybciej (przynajmniej ja tak uwazam :) )