### PR TITLE
refactor search mention and find mentions for player

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
             <version>5.1.0.Final</version>
         </dependency>
         <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-jpa</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
@@ -133,6 +137,29 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.mysema.maven</groupId>
+                <artifactId>apt-maven-plugin</artifactId>
+                <version>1.1.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>target/generated-sources</outputDirectory>
+                            <processor>com.querydsl.apt.QuerydslAnnotationProcessor</processor>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.querydsl</groupId>
+                        <artifactId>querydsl-apt</artifactId>
+                        <version>${querydsl.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/github/bpiatek/bbghbackend/controller/MentionsController.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/controller/MentionsController.java
@@ -5,17 +5,20 @@ import static org.mortbay.jetty.HttpStatus.ORDINAL_201_Created;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
 
+import com.github.bpiatek.bbghbackend.model.mention.Mention;
 import com.github.bpiatek.bbghbackend.model.mention.MentionFacade;
 import com.github.bpiatek.bbghbackend.model.mention.MentionSentiment;
 import com.github.bpiatek.bbghbackend.model.mention.api.CreateMentionRequest;
 import com.github.bpiatek.bbghbackend.model.mention.api.MentionResponse;
 import com.github.bpiatek.bbghbackend.model.mention.api.MentionSentimentRequest;
 import com.github.bpiatek.bbghbackend.swagger.ApiPageable;
+import com.querydsl.core.types.Predicate;
 import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
@@ -51,12 +54,23 @@ class MentionsController {
       @ApiResponse(code = ORDINAL_200_OK, message = "Successfully retrieved all mentions"),
   })
   @ApiPageable
-  @ApiImplicitParam(name = "ids", dataType = "array", paramType = "query", value = "Players ids. \n If you want to pass multiple ids separate them by commas ','")
   @GetMapping
   Page<MentionResponse> search(@ApiIgnore Pageable pageable,
-                               @RequestParam(required = false) List<MentionSentiment> sentiments,
-                               @RequestParam(required = false) List<Long> ids) {
-    return mentionFacade.search(pageable, sentiments, ids);
+                               @RequestParam(required = false) List<Long> id,
+                               @RequestParam(required = false) List<MentionSentiment> sentiment,
+                               @QuerydslPredicate(root = Mention.class) Predicate predicate) {
+    return mentionFacade.search(predicate, pageable);
+  }
+
+  @GetMapping("player")
+  @ApiResponses(value = {
+      @ApiResponse(code = ORDINAL_200_OK, message = "Successfully retrieved all mentions for specified player"),
+  })
+  @ApiPageable
+  Page<MentionResponse> searchByPlayersFullName(@ApiIgnore Pageable pageable,
+                                                @RequestParam String search) {
+
+    return mentionFacade.findByPlayersName(search, pageable);
   }
 
   @ApiOperation(value = "Create mention.")

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/article/Article.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/article/Article.java
@@ -2,6 +2,7 @@ package com.github.bpiatek.bbghbackend.model.article;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.bpiatek.bbghbackend.model.comment.Comment;
+import com.querydsl.core.annotations.QueryEntity;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ import javax.persistence.*;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@QueryEntity
 public class Article {
 
   @Id

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/comment/Comment.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/comment/Comment.java
@@ -3,6 +3,7 @@ package com.github.bpiatek.bbghbackend.model.comment;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.github.bpiatek.bbghbackend.model.article.Article;
 import com.github.bpiatek.bbghbackend.model.comment.api.CommentResponse;
+import com.querydsl.core.annotations.QueryEntity;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@QueryEntity
 public class Comment {
 
   @Id

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/mention/Mention.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/mention/Mention.java
@@ -3,6 +3,7 @@ package com.github.bpiatek.bbghbackend.model.mention;
 import com.github.bpiatek.bbghbackend.model.comment.Comment;
 import com.github.bpiatek.bbghbackend.model.mention.api.MentionResponse;
 import com.github.bpiatek.bbghbackend.model.player.Player;
+import com.querydsl.core.annotations.QueryEntity;
 import lombok.*;
 
 import javax.persistence.*;
@@ -17,6 +18,7 @@ import static javax.persistence.EnumType.STRING;
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@QueryEntity
 public class Mention {
 
   @Id

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/mention/MentionRepository.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/mention/MentionRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
@@ -13,7 +16,19 @@ import java.util.Optional;
 /**
  * @author Błażej Rybarkiewicz <b.rybarkiewicz@gmail.com>
  */
-interface MentionRepository extends Repository<Mention, Long> {
+interface MentionRepository extends Repository<Mention, Long>,
+                                    QuerydslPredicateExecutor<Mention>,
+                                    QuerydslBinderCustomizer<QMention> {
+
+  @Override
+  default void customize(QuerydslBindings bindings, QMention qMention) {
+    bindings.bind(qMention.id)
+        .all(((path, value) -> Optional.of(path.in(value))));
+
+    bindings.bind(qMention.sentiment)
+        .all(((path, value) -> Optional.of(path.in(value))));
+  }
+
   Mention save(Mention player);
 
   Page<Mention> findByCommentId(Long commentId, Pageable pageable);

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/player/Player.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/player/Player.java
@@ -1,6 +1,7 @@
 package com.github.bpiatek.bbghbackend.model.player;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.querydsl.core.annotations.QueryEntity;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -15,6 +16,7 @@ import javax.persistence.*;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@QueryEntity
 public class Player {
 
   @Id

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/player/PlayerRepository.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/player/PlayerRepository.java
@@ -21,15 +21,15 @@ interface PlayerRepository extends Repository<Player, Long> {
 
   Page<Player> findAll(Pageable pageable);
 
-  @Query(value = "SELECT DISTINCT last_name FROM Player", nativeQuery = true)
+  @Query(value = "SELECT DISTINCT last_name FROM player", nativeQuery = true)
   List<String> findDistinctLastNames();
 
-  @Query(value = "SELECT DISTINCT first_name FROM Player", nativeQuery = true)
+  @Query(value = "SELECT DISTINCT first_name FROM player", nativeQuery = true)
   List<String> findDistinctFirstNames();
 
-  Page<Player> findAllByFirstName(String firstName, Pageable pageable);
+  Page<Player> findAllByFirstNameIgnoreCase(String firstName, Pageable pageable);
 
-  Page<Player> findAllByLastName(String lastName, Pageable pageable);
+  Page<Player> findAllByLastNameIgnoreCase(String lastName, Pageable pageable);
 
-  Page<Player> findAllByFirstNameAndLastName(String firstName, String lastName, Pageable pageable);
+  Page<Player> findAllByFirstNameIgnoreCaseAndLastNameIgnoreCase(String firstName, String lastName, Pageable pageable);
 }

--- a/src/main/java/com/github/bpiatek/bbghbackend/model/player/PlayerSearcher.java
+++ b/src/main/java/com/github/bpiatek/bbghbackend/model/player/PlayerSearcher.java
@@ -1,5 +1,7 @@
 package com.github.bpiatek.bbghbackend.model.player;
 
+import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
@@ -32,7 +34,7 @@ class PlayerSearcher {
     List<String> distinctFirstNames = playerRepository.findDistinctFirstNames();
 
     return distinctFirstNames.stream()
-        .filter(text::contains)
+        .filter(firstName -> containsIgnoreCase(text, firstName))
         .findFirst();
   }
 
@@ -40,20 +42,20 @@ class PlayerSearcher {
     List<String> distinctLastNames = playerRepository.findDistinctLastNames();
 
     return distinctLastNames.stream()
-        .filter(text::contains)
+        .filter(lastName -> containsIgnoreCase(text, lastName))
         .findFirst();
   }
 
   private Page<Player> searchForPlayers(Optional<String> firstName, Optional<String> lastName, Pageable pageable) {
     if (firstAndLastNameIsPresent(firstName, lastName)) {
       log.info("Searching for PLAYER with firstName: {} and lastName: {}", firstName, lastName);
-      return playerRepository.findAllByFirstNameAndLastName(firstName.get(), lastName.get(), pageable);
+      return playerRepository.findAllByFirstNameIgnoreCaseAndLastNameIgnoreCase(firstName.get(), lastName.get(), pageable);
     } else if (onlyFirstNameIsPresent(firstName, lastName)) {
       log.info("Searching for PLAYER with firstName: {}", lastName);
-      return playerRepository.findAllByFirstName(firstName.get(), pageable);
+      return playerRepository.findAllByFirstNameIgnoreCase(firstName.get(), pageable);
     } else if (onlyLastNameIsPresent(firstName, lastName)) {
       log.info("Searching for PLAYER with lastName: {}", lastName);
-      return playerRepository.findAllByLastName(lastName.get(), pageable);
+      return playerRepository.findAllByLastNameIgnoreCase(lastName.get(), pageable);
     } else {
       return new PageImpl<>(new ArrayList<>());
     }


### PR DESCRIPTION
tutaj sa te zmiany, które potrzebuja delikatnego przerobienia frontu bo zapytanie sie delikatnie zmienilo tzn. przy wybraniu dwoch takich samych parametrow jego nazwa musi byc powtorzona:
`/api/mentions?id=1&id=2&page=0&sentiment=&size=20`
lub
`api/mentions?page=0&sentiment=POSITIVE&sentiment=NEGATIVE&size=20`

**Nie bede chyba mergowal dopuki nie bedziesz gotowy na ta zmiane**

P.S. Dodałem endpoint 
`http://localhost:8080/api/mentions/player?page=0&size=20&search=adamus`
gdzie jako `search` możesz przekazać imie i nazwisko (lub samo imie lub samo nazwisko) i znajdzie wzmianki dotyczace takiej osoby. 
Jak nie jest to potrzebne to mozna wywalić pozniej :)